### PR TITLE
Wait for the page to load before executing the script

### DIFF
--- a/spiraCommentaire.js
+++ b/spiraCommentaire.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name       Spira Commentaire
 // @namespace  http://use.i.E.your.homepage/
-// @version    1.5
+// @version    1.6
 // @description  enter something useful
 // @match      http://thefactory.crossknowledge.com/14/*
 // @match		http://thefactory.crossknowledge.com/10/*


### PR DESCRIPTION
In some cases the script won't execute because it couldn't find the DOM element to work on (the "#cplMainContent_pnlOverview_Comments .rteBack tr" element) when the page hasn't completely loaded.

My fix suggestion is to wait until the page has completely loaded to execute the script. 
